### PR TITLE
fix payments deactivated after apply-configuration console command

### DIFF
--- a/Core/Events.php
+++ b/Core/Events.php
@@ -270,6 +270,8 @@ class Events
      */
     protected static function deactivePaymentMethods()
     {
-        DatabaseProvider::getDb()->Execute("UPDATE oxpayments SET oxactive = 0 WHERE oxid IN ('".implode("','", array_keys(self::getMolliePaymentMethods()))."')");
+        if(Registry::getConfig()->isAdmin()) {
+            DatabaseProvider::getDb()->Execute("UPDATE oxpayments SET oxactive = 0 WHERE oxid IN ('".implode("','", array_keys(self::getMolliePaymentMethods()))."')");
+        }
     }
 }


### PR DESCRIPTION
When you run the command `oe:module:apply-configuration` all Payments get deactivated, this PR Fixes this by only running the Query if the Module was deactivated from Admin