### PR TITLE
Return 200 OK on IDs not known in the system

### DIFF
--- a/Application/Controller/MollieWebhook.php
+++ b/Application/Controller/MollieWebhook.php
@@ -29,12 +29,7 @@ class MollieWebhook extends FrontendController
             $oOrder = oxNew(Order::class);
             if ($oOrder->mollieLoadOrderByTransactionId($sTransactionId) === true) {
                 $oOrder->mollieGetPaymentModel()->getTransactionHandler()->processTransaction($oOrder);
-            } else {
-                // Throw HTTP error when order not found, this will trigger Mollie to retry sending the status
-                // For some payment methods the webhook is called before the order exists
-                Registry::getUtils()->setHeader("HTTP/1.1 409 Conflict");
-                Registry::getUtils()->showMessageAndExit("");
-            }
+            } 
         }
 
         return $this->_sThisTemplate;


### PR DESCRIPTION
This PR touches code in the Webhook.

When the webhook is called with an ID which is not in the backend, it returns a 409 HTTP status code. This reveals that the ID of that transaction does not belong to the merchant. As stated in the [Mollie docs](https://docs.mollie.com/overview/webhooks):

"To not leak any information to malicious third parties, it is recommended to return a 200 OK response even if the ID is not known to your system."

Because of this, I have deleted the lines of code which change the response code to 409 HTTP response when the order id did not match with any order id in the backend. Checked a few other integrations and they seem to do this properly (always return 200 OK).

**Scenario to test this code:**

Once installed, call the webhook of the webshop with any transaction/order id. The webhook should return a 200 OK even if the transaction is not in the backend.

<3 From Mollie TS 