### PR TITLE
PIOXD-414 Add Wero payment method

### DIFF
--- a/Application/Helper/Payment.php
+++ b/Application/Helper/Payment.php
@@ -55,6 +55,7 @@ class Payment
         'molliepaybybank'       => array('title' => 'Pay by Bank',         'model' => \Mollie\Payment\Application\Model\Payment\PayByBank::class),
         'molliesatispay'        => array('title' => 'Satispay',            'model' => \Mollie\Payment\Application\Model\Payment\Satispay::class),
         'mollieswish'           => array('title' => 'Swish',               'model' => \Mollie\Payment\Application\Model\Payment\Swish::class),
+        'molliewero'            => array('title' => 'Wero',                'model' => \Mollie\Payment\Application\Model\Payment\Wero::class),
     );
 
     /**

--- a/Application/Model/Payment/Wero.php
+++ b/Application/Model/Payment/Wero.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Mollie\Payment\Application\Model\Payment;
+
+class Wero extends Base
+{
+    /**
+     * Payment id in the oxid shop
+     *
+     * @var string
+     */
+    protected $sOxidPaymentId = 'molliewero';
+
+    /**
+     * Method code used for API request
+     *
+     * @var string
+     */
+    protected $sMolliePaymentCode = 'wero';
+
+    /**
+     * If filled, the payment method will only be shown if one of the allowed currencies is active in checkout
+     *
+     * @var array
+     */
+    protected $aAllowedCurrencies = [
+        'EUR',
+    ];
+
+    /**
+     * Array with country-codes the payment method is restricted to
+     * If property is set to false it is available to all countries
+     *
+     * @var array|false
+     */
+    protected $aBillingCountryRestrictedTo = [
+        'DE', 'BE', 'FR', 'LU',
+    ];
+}


### PR DESCRIPTION
## Summary

- Adds Wero as a new payment method (Mollie API code: `wero`, OXID ID: `molliewero`)
- EUR-only, restricted to billing countries: DE, BE, FR, LU
- Payment method is auto-inserted into `oxpayments` on module activation via `Core/Events.php`

## Changes

- `Application/Model/Payment/Wero.php` — new payment model class
- `Application/Helper/Payment.php` — registered `molliewero` in the payment methods list

Jira: https://mollie.atlassian.net/browse/PIOXD-414